### PR TITLE
Fix/improve SPDX headers in makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Copyright 2020 StarFive #
-# SPDX-License-Identifier: Apache-2.0 #
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2020 StarFiveTech, Inc.
 
 EMPTY  :=
 SPACE  := $(EMPTY) $(EMPTY)

--- a/debug.mk
+++ b/debug.mk
@@ -1,5 +1,5 @@
-#/* SPDX-License-Identifier: GPL-2.0-or-later */
-#/* Copyright (c) 2020 StarFiveTech, Inc */
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2020 StarFiveTech, Inc
 ###################################################
 # Build Flags for the Debug Configuration
 ###################################################

--- a/release.mk
+++ b/release.mk
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
-/* Copyright (c) 2020 StarFiveTech, Inc */
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (c) 2020 StarFiveTech, Inc
 ###################################################
 # Build Flags for the Release Configuration
 ###################################################


### PR DESCRIPTION
Specifically, release.mk has invalid syntax.